### PR TITLE
Switch to TCP health probes for MCP services

### DIFF
--- a/k8s-deployment/mcp-neo4j-cypher.yaml
+++ b/k8s-deployment/mcp-neo4j-cypher.yaml
@@ -90,18 +90,16 @@ spec:
             drop:
               - ALL
         livenessProbe:
-          httpGet:
-            path: /api/mcp/health
+          tcpSocket:
             port: 8001
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
         readinessProbe:
-          httpGet:
-            path: /api/mcp/health
+          tcpSocket:
             port: 8001
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
           timeoutSeconds: 3
           successThreshold: 1

--- a/k8s-deployment/mcp-neo4j-data-modeling.yaml
+++ b/k8s-deployment/mcp-neo4j-data-modeling.yaml
@@ -70,18 +70,16 @@ spec:
             drop:
               - ALL
         livenessProbe:
-          httpGet:
-            path: /api/mcp/health
+          tcpSocket:
             port: 8004
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
         readinessProbe:
-          httpGet:
-            path: /api/mcp/health
+          tcpSocket:
             port: 8004
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
           timeoutSeconds: 3
           successThreshold: 1

--- a/k8s-deployment/mcp-neo4j-memory.yaml
+++ b/k8s-deployment/mcp-neo4j-memory.yaml
@@ -90,18 +90,16 @@ spec:
             drop:
               - ALL
         livenessProbe:
-          httpGet:
-            path: /api/mcp/health
+          tcpSocket:
             port: 8002
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
         readinessProbe:
-          httpGet:
-            path: /api/mcp/health
+          tcpSocket:
             port: 8002
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
           timeoutSeconds: 3
           successThreshold: 1


### PR DESCRIPTION
## Summary

Fix health check probe implementation by switching from HTTP to TCP probes.

- Change from HTTP `/api/mcp/health` to TCP socket probes
- FastMCP doesn't expose dedicated health check endpoints  
- TCP connection test is sufficient to verify service availability
- Increases readiness probe initial delay to 10s for better stability

## Problem

FastMCP services were returning `406 Not Acceptable` for HTTP health checks because the framework doesn't expose dedicated health endpoints. Kubernetes was interpreting this as health check failures, causing continuous restarts.

## Solution  

Use TCP socket probes instead:
- Tests if the service is accepting connections on its port
- More reliable for services without explicit health endpoints
- Reduces false positive health check failures

## Test Plan

- [x] Verify TCP probes can connect to service ports
- [ ] Confirm pods reach Ready status without probe failures
- [ ] Validate services are accessible through ingress

🤖 Generated with [Claude Code](https://claude.ai/code)