### PR TITLE
fix: Resolve Google Managed Certificate ingress configuration issues

### DIFF
--- a/k8s-deployment/ingress.yaml
+++ b/k8s-deployment/ingress.yaml
@@ -9,10 +9,6 @@ metadata:
     networking.gke.io/managed-certificates: "mcp-neo4j-cert"
     kubernetes.io/ingress.allow-http: "false"
 spec:
-  tls:
-  - hosts:
-    - INGRESS_HOST
-    secretName: mcp-neo4j-cert-secret
   rules:
   - host: INGRESS_HOST
     http:


### PR DESCRIPTION
## Summary

This PR fixes critical ingress configuration issues for Google Managed Certificates.

## Issues Fixed

- **TLS Configuration Error**: Removed  section from ingress spec which was causing 'secret does not exist' errors
- **Load Balancer Sync**: Ingress now properly syncs with GKE load balancer
- **Static IP Assignment**: Neo4j ingress successfully obtains static IP (34.54.166.8)

## Changes

- Remove  from ingress specification  
- Google Managed Certificates automatically handle TLS configuration
- Ingress sync errors resolved

## Verification

- Ingress obtains proper IP address assignment
- Load balancer sync completes successfully
- Certificate provisioning proceeds normally

## DNS Configuration

Requires Cloudflare DNS:
- `mcp-neo4j.memenow.net → 34.54.166.8`