### PR TITLE
Fix health check configuration: change from HTTP to TCP socket checks

### DIFF
--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: Create Neo4j Secret
       run: |
-        kubectl create secret generic mcp-neo4j-secret \
+        kubectl create secret generic mcp-credentials \
           --from-literal=NEO4J_USERNAME=neo4j \
           --from-literal=NEO4J_PASSWORD="${{ secrets.NEO4J_PASSWORD }}" \
           --from-literal=NEO4J_AURA_CLIENT_ID="${{ secrets.NEO4J_AURA_CLIENT_ID }}" \

--- a/k8s/overlays/production/patches.yaml
+++ b/k8s/overlays/production/patches.yaml
@@ -9,12 +9,100 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
-      nodeSelector:
-        $patch: delete
-      tolerations:
-        $patch: delete
-      affinity:
-        $patch: delete
+      $patch: replace
+      serviceAccountName: mcp-neo4j-sa
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+      - name: cypher
+        image: ghcr.io/memenow/mcp-neo4j-cypher:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8001
+          name: http
+          protocol: TCP
+        env:
+        - name: NEO4J_URI
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: NEO4J_URI
+        - name: NEO4J_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: NEO4J_DATABASE
+        - name: NEO4J_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: mcp-credentials
+              key: NEO4J_USERNAME
+        - name: NEO4J_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mcp-credentials
+              key: NEO4J_PASSWORD
+        - name: NEO4J_TRANSPORT
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: NEO4J_TRANSPORT
+        - name: NEO4J_MCP_SERVER_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: NEO4J_MCP_SERVER_HOST
+        - name: NEO4J_MCP_SERVER_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: CYPHER_PORT
+        - name: NEO4J_MCP_SERVER_PATH
+          value: "/api/mcp/"
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: LOG_LEVEL
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "50m"
+            ephemeral-storage: "100Mi"
+          limits:
+            memory: "256Mi"
+            cpu: "250m"
+            ephemeral-storage: "200Mi"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+        livenessProbe:
+          tcpSocket:
+            port: 8001
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          tcpSocket:
+            port: 8001
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+          readOnly: false
+      volumes:
+      - name: tmp
+        emptyDir: {}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -26,12 +114,100 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
-      nodeSelector:
-        $patch: delete
-      tolerations:
-        $patch: delete
-      affinity:
-        $patch: delete
+      $patch: replace
+      serviceAccountName: mcp-neo4j-sa
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+      - name: memory
+        image: ghcr.io/memenow/mcp-neo4j-memory:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8002
+          name: http
+          protocol: TCP
+        env:
+        - name: NEO4J_URL
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: NEO4J_URI
+        - name: NEO4J_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: NEO4J_DATABASE
+        - name: NEO4J_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: mcp-credentials
+              key: NEO4J_USERNAME
+        - name: NEO4J_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mcp-credentials
+              key: NEO4J_PASSWORD
+        - name: NEO4J_TRANSPORT
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: NEO4J_TRANSPORT
+        - name: NEO4J_MCP_SERVER_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: NEO4J_MCP_SERVER_HOST
+        - name: NEO4J_MCP_SERVER_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: MEMORY_PORT
+        - name: NEO4J_MCP_SERVER_PATH
+          value: "/api/mcp/"
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: LOG_LEVEL
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "50m"
+            ephemeral-storage: "100Mi"
+          limits:
+            memory: "256Mi"
+            cpu: "250m"
+            ephemeral-storage: "200Mi"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+        livenessProbe:
+          tcpSocket:
+            port: 8002
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          tcpSocket:
+            port: 8002
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+          readOnly: false
+      volumes:
+      - name: tmp
+        emptyDir: {}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -43,9 +219,101 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
-      nodeSelector:
-        $patch: delete
-      tolerations:
-        $patch: delete
-      affinity:
-        $patch: delete
+      $patch: replace
+      serviceAccountName: mcp-neo4j-sa
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+      - name: modeling
+        image: ghcr.io/memenow/mcp-neo4j-data-modeling:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8004
+          name: http
+          protocol: TCP
+        env:
+        - name: NEO4J_URI
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: NEO4J_URI
+        - name: NEO4J_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: NEO4J_DATABASE
+        - name: NEO4J_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: mcp-credentials
+              key: NEO4J_USERNAME
+        - name: NEO4J_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mcp-credentials
+              key: NEO4J_PASSWORD
+        - name: NEO4J_TRANSPORT
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: NEO4J_TRANSPORT
+        - name: NEO4J_MCP_SERVER_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: NEO4J_MCP_SERVER_HOST
+        - name: NEO4J_MCP_SERVER_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: MODELING_PORT
+        - name: NEO4J_MCP_SERVER_PATH
+          value: "/api/mcp/"
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: mcp-app-config
+              key: LOG_LEVEL
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "50m"
+            ephemeral-storage: "100Mi"
+          limits:
+            memory: "256Mi"
+            cpu: "250m"
+            ephemeral-storage: "200Mi"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+        livenessProbe:
+          tcpSocket:
+            port: 8004
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          tcpSocket:
+            port: 8004
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+          readOnly: false
+        - name: venv
+          mountPath: /app/venv
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: venv
+        emptyDir: {}

--- a/k8s/overlays/production/patches.yaml
+++ b/k8s/overlays/production/patches.yaml
@@ -9,9 +9,12 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
-      nodeSelector: null
-      tolerations: null
-      affinity: null
+      nodeSelector:
+        $patch: delete
+      tolerations:
+        $patch: delete
+      affinity:
+        $patch: delete
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -23,9 +26,12 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
-      nodeSelector: null
-      tolerations: null
-      affinity: null
+      nodeSelector:
+        $patch: delete
+      tolerations:
+        $patch: delete
+      affinity:
+        $patch: delete
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -37,6 +43,9 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
-      nodeSelector: null
-      tolerations: null
-      affinity: null
+      nodeSelector:
+        $patch: delete
+      tolerations:
+        $patch: delete
+      affinity:
+        $patch: delete


### PR DESCRIPTION
## Problem
The health checks were configured to use HTTP GET requests to `/health` endpoints, but FastMCP framework does not provide default health endpoints. This caused liveness and readiness probes to fail with 404 errors: `Liveness probe failed: HTTP probe failed with statuscode: 404`.

## Root Cause Analysis
- **FastMCP Framework**: jlowin/fastmcp Python framework with `stateless_http=True` does not automatically provide `/health` endpoints
- **Service Configuration**: Services run on ports 8001, 8002, 8004 with path `/api/mcp/` but no health endpoint
- **Previous HTTP Checks**: Were attempting to GET `/health` which returned 404 Not Found

## Solution
Changed health check configuration from HTTP to TCP socket checks:
- **TCP Socket Checks**: Verify that the service is listening on the specified port (more appropriate for MCP servers)
- **Complete Pod Spec**: Used `$patch: replace` to completely override pod specifications
- **Removed Scheduling Constraints**: Eliminated nodeSelector/tolerations/affinity that prevented GKE Autopilot scheduling
- **Fixed Secret References**: Ensured consistent use of `mcp-credentials` secret name

## Technical Details
- **Health Check Method**: Changed from `httpGet` to `tcpSocket` probes for all three services
- **Port Configuration**: 
  - mcp-cypher: port 8001
  - mcp-memory: port 8002  
  - mcp-modeling: port 8004
- **Probe Timing**: Maintained existing timing configuration (liveness: 30s delay, readiness: 10s delay)

## Files Changed
- `k8s/overlays/production/patches.yaml`: Complete rewrite of health check configuration
- Previous commits also fixed workflow secret name consistency

## Expected Results
- ✅ Pods should pass health checks using TCP socket connectivity
- ✅ Eliminates 404 errors from non-existent `/health` endpoints  
- ✅ Allows successful deployment on GKE Autopilot
- ✅ Proper authentication using correct secret names

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>